### PR TITLE
Fix/redirect wrangler output

### DIFF
--- a/src/functions.erl
+++ b/src/functions.erl
@@ -115,6 +115,7 @@ find_callers({FileName, FunName, Arity}, CommitHash) ->
     % so this should ideally be done in some smarter way
     repo:checkout(CommitHash),
     {_, Folder} = file:get_cwd(),
-    % TODO Stop wrangler from printing to stdout
+    Leader = utils:disable_output(),
     {_, Funs} = wrangler_code_inspector_lib:calls_to_fun_1(FileName, FunName, Arity, [Folder], 4),
+    utils:enable_output(Leader),
     lists:map(fun({{FileName, F, A}, _}) -> {FileName, {utils:filename_to_module(FileName), F, A}} end, Funs).

--- a/src/utils.erl
+++ b/src/utils.erl
@@ -72,7 +72,7 @@ dummy_group_leader() ->
 
 
 % Disables the output by using the dummy group leader
-% Gives back the old group leader, so output could be reenable later
+% Gives back the old group leader, so output could be reenabled later
 % by the enable_output/1 function
 -spec disable_output() -> pid().
 disable_output() ->

--- a/src/utils.erl
+++ b/src/utils.erl
@@ -60,6 +60,9 @@ filename_to_module(FileName) ->
 module_to_filename(Module) ->
     erlang:atom_to_list(Module) ++ ".erl".
 
+% This is a dummy process for suppressing any io message sent to it
+% It works by just simply ignoring the message, and sending back an 'ok' reply
+% accoring to the I/O protocol (https://www.erlang.org/doc/apps/stdlib/io_protocol.html)
 dummy_group_leader() ->
     receive
         {io_request, From, ReplyAs, _} ->
@@ -68,6 +71,9 @@ dummy_group_leader() ->
     end.
 
 
+% Disables the output by using the dummy group leader
+% Gives back the old group leader, so output could be reenable later
+% by the enable_output/1 function
 -spec disable_output() -> pid().
 disable_output() ->
     Old = group_leader(),

--- a/src/utils.erl
+++ b/src/utils.erl
@@ -64,8 +64,7 @@ dummy_group_leader() ->
     receive
         {io_request, From, ReplyAs, _} ->
             From ! {io_reply, ReplyAs, ok},
-            dummy_group_leader();
-        exit -> ok
+            dummy_group_leader()
     end.
 
 

--- a/src/utils.erl
+++ b/src/utils.erl
@@ -59,3 +59,23 @@ filename_to_module(FileName) ->
 -spec module_to_filename(atom()) -> string().
 module_to_filename(Module) ->
     erlang:atom_to_list(Module) ++ ".erl".
+
+dummy_group_leader() ->
+    receive
+        {io_request, From, ReplyAs, _} ->
+            From ! {io_reply, ReplyAs, ok},
+            dummy_group_leader();
+        exit -> ok
+    end.
+
+
+-spec disable_output() -> pid().
+disable_output() ->
+    Old = group_leader(),
+    New = spawn(utils, dummy_group_leader, []),
+    group_leader(New, self()),
+    Old.
+
+-spec enable_output(pid()) -> none().
+enable_output(Leader) ->
+    group_leader(Leader, self()).


### PR DESCRIPTION
Suppresses the output of Wrangler by setting the group leader to a dummy process which does nothing with the io message.